### PR TITLE
Gnome App dbus fixes (for tag as 0.0.2)

### DIFF
--- a/src/env.d/00-locale
+++ b/src/env.d/00-locale
@@ -2,10 +2,12 @@
 
 # The user's primary language (defaults to American English)
 # It is HIGHLY RECOMMENDED to use a UTF-8 locale
-LANG="POSIX"
+# LANG="POSIX"
+# Gnome apps require a UTF-8 LANG to be set.
+: "${LANG:=en_US.UTF-8}"
 
 # A colon-delineated list of languages the user knows. Defaults to LANG.
-LANGUAGE="POSIX"
+# LANGUAGE="POSIX"
 
 # Extra variables that override the LANG setting
 #LC_CTYPE=

--- a/src/env.d/03-dbus
+++ b/src/env.d/03-dbus
@@ -1,7 +1,7 @@
 # Dbus settings
 DBUS_SYSTEM_BUS_ADDRESS='unix:path=/var/run/dbus/system_bus_socket'
 [[ "$DBUS_SESSION_BUS_ADDRESS"=="disabled:" ]] && unset DBUS_SESSION_BUS_ADDRESS
-if test -z "$DBUS_SESSION_BUS_ADDRESS" ; then
+if [ -z "${DBUS_SESSION_BUS_ADDRESS}" ]; then
   # if not found, launch a new one
   eval `dbus-launch --sh-syntax`
   # echo "D-Bus per-session daemon address is: $DBUS_SESSION_BUS_ADDRESS"

--- a/src/env.d/03-dbus
+++ b/src/env.d/03-dbus
@@ -1,5 +1,5 @@
 # Dbus settings
-DBUS_SYSTEM_BUS_ADDRESS='unix:path=/run/dbus/system_bus_socket'
+DBUS_SYSTEM_BUS_ADDRESS='unix:path=/var/run/dbus/system_bus_socket'
 [[ "$DBUS_SESSION_BUS_ADDRESS"=="disabled:" ]] && unset DBUS_SESSION_BUS_ADDRESS
 if test -z "$DBUS_SESSION_BUS_ADDRESS" ; then
   # if not found, launch a new one

--- a/src/env.d/03-dbus
+++ b/src/env.d/03-dbus
@@ -1,0 +1,9 @@
+# Dbus settings
+DBUS_SYSTEM_BUS_ADDRESS='unix:path=/run/dbus/system_bus_socket'
+[[ "$DBUS_SESSION_BUS_ADDRESS"=="disabled:" ]] && unset DBUS_SESSION_BUS_ADDRESS
+if test -z "$DBUS_SESSION_BUS_ADDRESS" ; then
+  # if not found, launch a new one
+  eval `dbus-launch --sh-syntax`
+  # echo "D-Bus per-session daemon address is: $DBUS_SESSION_BUS_ADDRESS"
+fi
+dbus-update-activation-environment --all

--- a/src/env.d/04-iconv
+++ b/src/env.d/04-iconv
@@ -1,0 +1,2 @@
+# Set GCONV_PATH since the built-in glibc files are limited, causing iconv checks fail.
+GCONV_PATH=${CREW_LIB_PREFIX}/gconv

--- a/src/profile
+++ b/src/profile
@@ -7,6 +7,20 @@
 # Source the base /etc/profile file
 source /etc/profile
 
+ARCH="$(uname -m)"
+# For container usage, where we are emulating armv7l via linux32
+ARCH="${ARCH/armv8l/armv7l}"
+case "${ARCH}" in
+"i686"|"armv7l"|"aarch64")
+  LIB_SUFFIX=''
+  ;;
+'x86_64')
+  LIB_SUFFIX='64'
+  ;;
+*)
+  ;;
+esac
+
 # Export variables set (set allexport)
 set -a
 
@@ -15,6 +29,8 @@ CREW_PREFIX="$(crew const CREW_PREFIX | sed -e 's:CREW_PREFIX=::g')"
 # If crew is broken, we still want CREW_PREFIX set, otherwise we
 # get breakage from files in /etc/env.d being sourced.
 : "${CREW_PREFIX:=/usr/local}"
+
+: "${CREW_LIB_PREFIX:=/usr/local/lib$LIB_SUFFIX}"
 
 # Find system configuration directory
 CREW_SYSCONFDIR="${CREW_PREFIX}/etc"
@@ -31,12 +47,12 @@ if [ -d ${CREW_SYSCONFDIR}/profile.d ]; then
 fi
 
 # Load the bash directory
-if [ ! -z "${BASH}" ]; then
+if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [[ -f $i ]] && source "${i}"; done
 fi
 
 # Load the zsh directory
-if [ ! -z "${ZSH_NAME}" ]; then
+if [ -n "${ZSH_NAME}" ]; then
   for i in "${CREW_SYSCONFDIR}"/zsh.d/*; do [[ -f $i ]] && source "${i}"; done
 fi
 

--- a/src/profile
+++ b/src/profile
@@ -7,6 +7,9 @@
 # Source the base /etc/profile file
 source /etc/profile
 
+# Export variables set (set allexport)
+set -a
+
 # Find chromebrew prefix
 CREW_PREFIX="$(crew const CREW_PREFIX | sed -e 's:CREW_PREFIX=::g')"
 
@@ -17,19 +20,23 @@ CREW_SYSCONFDIR="${CREW_PREFIX}/etc"
 set +h
 
 # Load the environment
-for i in "${CREW_SYSCONFDIR}"/env.d/*; do source "${i}"; done
+for i in "${CREW_SYSCONFDIR}"/env.d/*; do [[ -f $i ]] && source "${i}"; done
 
 # Load the profile
-if [ -d ${SYSCONFDIR}/profile.d ]; then
-  for i in "${CREW_SYSCONFDIR}"/profile.d/*.sh; do source "${i}"; done
+if [ -d ${CREW_SYSCONFDIR}/profile.d ]; then
+  for i in "${CREW_SYSCONFDIR}"/profile.d/*.sh; do [[ -f $i ]] && source "${i}"; done
 fi
 
 # Load the bash directory
 if [ ! -z "${BASH}" ]; then
-  for i in "${CREW_SYSCONFDIR}"/bash.d/*; do source "${i}"; done
+  for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [[ -f $i ]] && source "${i}"; done
 fi
 
 # Load the zsh directory
 if [ ! -z "${ZSH_NAME}" ]; then
-  for i in "${CREW_SYSCONFDIR}"/zsh.d/*; do source "${i}"; done
+  for i in "${CREW_SYSCONFDIR}"/zsh.d/*; do [[ -f $i ]] && source "${i}"; done
 fi
+
+unset i
+# Stop exporting variables set (unset allexport)
+set +a

--- a/src/profile
+++ b/src/profile
@@ -12,6 +12,9 @@ set -a
 
 # Find chromebrew prefix
 CREW_PREFIX="$(crew const CREW_PREFIX | sed -e 's:CREW_PREFIX=::g')"
+# If crew is broken, we still want CREW_PREFIX set, otherwise we
+# get breakage from files in /etc/env.d being sourced.
+: "${CREW_PREFIX:=/usr/local}"
 
 # Find system configuration directory
 CREW_SYSCONFDIR="${CREW_PREFIX}/etc"


### PR DESCRIPTION
These are fixes for https://github.com/skycocker/chromebrew/issues/5936 once we have this tagged as `0.0.2` and we have `crew_profile_base` modified accordingly in an upcoming PR.

- This sets the dbus variables appropriately and also sets a UTF-8 locale. These are needed for Gnome Apps.
- This sets GCONV_PATH to CREW_LIB_PREFIX/gconv so that iconv works properly. (Removes need for libiconv.) (Note that this needs CREW_LIB_PREFIX set too...)
- These can be overridden by modifying the 99-locale file if necessary.
- Also, files are only sourced once they are confirmed to be files, and not directories. (Dev_install can drop directories into /usr/local/etc/env.d )