### PR TITLE
Make home follow symlinks and be executable

### DIFF
--- a/src/env.d/06-home
+++ b/src/env.d/06-home
@@ -1,0 +1,4 @@
+# Sets the user's home directory to executable and symfollow. Avoids other package-specific workarounds.
+if ! grep -Eq '^[^ ]+ /home/chronos/user [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
+  sudo mount -o remount,rw,exec,symfollow "${HOME}"
+fi


### PR DESCRIPTION
This will erase the need for weird workarounds in packages like `flatpak`, `minecraft`, `stack`, `go`, etc., especially since Milestone 90 which broke symlinks in the home directory. `~/Downloads` retains its default settings.

To be tagged as `0.1.0`