### PR TITLE
profile: Do not use `crew` to get `CREW_PREFIX` 

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -25,7 +25,9 @@ esac
 set -a
 
 # Find chromebrew prefix
+# same logic can be found in lib/const.rb, line 17-25
 : "${CREW_PREFIX:=/usr/local}"
+
 : "${CREW_LIB_PREFIX:=$CREW_PREFIX/lib$LIB_SUFFIX}"
 
 # Find system configuration directory

--- a/src/profile
+++ b/src/profile
@@ -26,8 +26,7 @@ set -a
 
 # Find chromebrew prefix
 : "${CREW_PREFIX:=/usr/local}"
-
-: "${CREW_LIB_PREFIX:=/usr/local/lib$LIB_SUFFIX}"
+: "${CREW_LIB_PREFIX:=$CREW_PREFIX/lib$LIB_SUFFIX}"
 
 # Find system configuration directory
 CREW_SYSCONFDIR="${CREW_PREFIX}/etc"

--- a/src/profile
+++ b/src/profile
@@ -25,9 +25,6 @@ esac
 set -a
 
 # Find chromebrew prefix
-CREW_PREFIX="$(crew const CREW_PREFIX | sed -e 's:CREW_PREFIX=::g')"
-# If crew is broken, we still want CREW_PREFIX set, otherwise we
-# get breakage from files in /etc/env.d being sourced.
 : "${CREW_PREFIX:=/usr/local}"
 
 : "${CREW_LIB_PREFIX:=/usr/local/lib$LIB_SUFFIX}"


### PR DESCRIPTION
The startup time of `crew` is slow due to the bad performance of `docopt.rb` and `ruby`, resulting in ~0.8sec lag after typing `shell` in `crosh` and before dropping into `bash`
```
$ time crew const CREW_PREFIX
CREW_PREFIX=/usr/local

real    0m0.514s
user    0m0.501s
sys     0m0.013s
```


If `crew` is slow, why not get `CREW_PREFIX` in `bash` using the same logic in `const.rb`:)