### PR TITLE
Do 'Is there a newer version of bash?' check earlier from /usr/local/etc/profile

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -8,7 +8,7 @@
 # Switch to Chromebrew bash as early as possible if it is installed.
 CREW_BASH_VERSION="$(bash --norc -c 'echo $BASH_VERSION')"
 if [[ -n "$CREW_BASH_VERSION" ]] && [[ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]]; then
-  echo "Starting newer Chromebrew bash"
+  echo "Starting newer Chromebrew bash."
   exec bash
 # else
   # echo "Chromebrew bash is not newer."

--- a/src/profile
+++ b/src/profile
@@ -5,8 +5,7 @@
 # custom scripting to profile.d/99-custom
 
 # Bash in path will be the Chromebrew bash if it is installed.
-# Doing this switch as early as possible avoids weird issues.
-# See https://github.com/chromebrew/chromebrew/issues/7462
+# Switch to Chromebrew bash as early as possible if it is installed.
 CREW_BASH_VERSION="$(bash --norc -c 'echo $BASH_VERSION')"
 if [[ -n "$CREW_BASH_VERSION" ]] && [[ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]]; then
   echo "Starting newer Chromebrew bash"

--- a/src/profile
+++ b/src/profile
@@ -7,8 +7,9 @@
 # Bash in path will be the Chromebrew bash if it is installed.
 # Doing this switch as early as possible avoids weird issues.
 # See https://github.com/chromebrew/chromebrew/issues/7462
-if [[ "$(bash -c 'echo $BASH_VERSION')" != "${BASH_VERSION}" ]]; then
-  echo "Starting newer Chromebrew bash."
+CREW_BASH_VERSION="$(bash --norc -c 'echo $BASH_VERSION')"
+if [[ -n "$CREW_BASH_VERSION" ]] && [[ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]]; then
+  echo "Starting newer Chromebrew bash"
   exec bash
 # else
   # echo "Chromebrew bash is not newer."

--- a/src/profile
+++ b/src/profile
@@ -8,10 +8,10 @@
 # Switch to Chromebrew bash as early as possible if it is installed.
 CREW_BASH_VERSION="$(bash --norc -c 'echo $BASH_VERSION')"
 if [[ -n "$CREW_BASH_VERSION" ]] && [[ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]]; then
-  echo "Starting newer Chromebrew bash."
+  echo "Starting Chromebrew bash."
   exec bash
 # else
-  # echo "Chromebrew bash is not newer."
+  # echo "Chromebrew bash is not installed."
 fi
 
 # Source the base /etc/profile file

--- a/src/profile
+++ b/src/profile
@@ -4,6 +4,16 @@
 # Instead, add custom environment variables to env.d/99-custom and
 # custom scripting to profile.d/99-custom
 
+# Bash in path will be the Chromebrew bash if it is installed.
+# Doing this switch as early as possible avoids weird issues.
+# See https://github.com/chromebrew/chromebrew/issues/7462
+if [[ "$(bash -c 'echo $BASH_VERSION')" != "${BASH_VERSION}" ]]; then
+  echo "Starting newer Chromebrew bash."
+  exec bash
+# else
+  # echo "Chromebrew bash is not newer."
+fi
+
 # Source the base /etc/profile file
 source /etc/profile
 


### PR DESCRIPTION
Partial fix for issue in https://github.com/chromebrew/chromebrew/issues/7462
This is part of the fixes in https://github.com/chromebrew/chromebrew/pull/7572 and replaces the bash loading logic in bash's `bash.d` file.