### PR TITLE
escape bash version since it has parenthesis in output

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -23,7 +23,7 @@ set +a
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
 if [ -x "$CREW_PREFIX/bin/bash" ]; then
-  CREW_BASH_VERSION=$("$CREW_PREFIX"/bin/bash --norc -c "echo $BASH_VERSION")
+  CREW_BASH_VERSION=$("$CREW_PREFIX"/bin/bash --norc -c "echo \"$BASH_VERSION\"")
   if [ -n "$CREW_BASH_VERSION" ] && [ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]; then
     echo "Starting Chromebrew bash."
     exec "$CREW_PREFIX"/bin/bash


### PR DESCRIPTION
Fixes this issue of bash not wanting to echo text not in parenthesis:
```
+++ export 'PS4=+(${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+++ PS4='+(${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+++(27): '[' -x /usr/local/bin/bash ']'
++++(28): /usr/local/bin/bash --norc -c 'echo 5.1.16(1)-release'
/usr/local/bin/bash: -c: line 1: syntax error near unexpected token `('
/usr/local/bin/bash: -c: line 1: `echo 5.1.16(1)-release'
+++(28): CREW_BASH_VERSION=
```
with this fix:
`CREW_BASH_VERSION=$("$CREW_PREFIX"/bin/bash --norc -c "echo \"$BASH_VERSION\"")`