### PR TITLE
Fix error when no matching result are found in crew autocomplete

### DIFF
--- a/src/bash.d/01-crew
+++ b/src/bash.d/01-crew
@@ -12,7 +12,7 @@ function _crew () {
     --color
     --no-color
     --keep
-    --license 
+    --license
     --build-from-source
     --recursive-build
     --verbose
@@ -55,9 +55,9 @@ function _crew () {
     # match ${current} with available packages
     local matched_pkgs=( ${CREW_PACKAGES_PATH}/${current}*.rb )
 
-    if [[ ${#matched_pkgs[@]} != 0 ]]; then
-      # use ls and basename to remove extension and path
-      COMPREPLY=( $(ls -1 ${matched_pkgs[@]} | xargs basename -s .rb) )
+    if [[ ${#matched_pkgs[@]} > 1 ]]; then
+      # use basename to remove extension and path
+      COMPREPLY=( $(basename -s .rb ${matched_pkgs[@]}) )
     else
       return 1
     fi


### PR DESCRIPTION
### Changes
- Fix error when no matching result were found in `crew install`:
```
$ crew install test
ls: cannot access '/usr/local/lib/crew/packages//test*.rb': No such file or directory
basename: missing operand
Try 'basename --help' for more information.
ls: cannot access '/usr/local/lib/crew/packages//test*.rb': No such file or directory
```
- Delete trailing space
- Simplify to use `basename` only when removing `.rb` extension

Tested on `x86_64`