### PR TITLE
00-path: Only add musl bin to path if musl is installed

### DIFF
--- a/src/env.d/00-path
+++ b/src/env.d/00-path
@@ -9,7 +9,10 @@
 
 [[ "$PATH" == *"${CREW_PREFIX}/sbin"* ]] || export PATH="${PATH}:${CREW_PREFIX}/sbin"
 
-[[ "$PATH" == *"${CREW_PREFIX}/share/musl/bin"* ]] || export PATH="${PATH}:${CREW_PREFIX}/share/musl/bin"
+# Only add musl bin to path if musl is installed.
+if [ -d "${CREW_PREFIX}/share/musl/bin" ]; then
+  [[ "$PATH" == *"${CREW_PREFIX}/share/musl/bin"* ]] || export PATH="${PATH}:${CREW_PREFIX}/share/musl/bin"
+fi
 
 # Give TMPDIR standard permissions
 if [ "$(stat -c %a "${TMPDIR:-/usr/local/tmp}")" -ne 1777 ]; then


### PR DESCRIPTION
This change implements only adding the musl bin path if musl packages are installed.

This also requires all musl packages to be modified to add `print_source_bashrc`.