### PR TITLE
Remove ARCH variable export, allow autocompletion to handle files in CREW_LOCAL_REPO_ROOT

### DIFF
--- a/src/bash.d/01-crew
+++ b/src/bash.d/01-crew
@@ -5,9 +5,9 @@ function _crew () {
   local CREW_PACKAGES_PATH="${CREW_PREFIX}/lib/crew/packages/"
   local CREW_LOCAL_REPO_ROOT="$(git rev-parse --show-toplevel 2> /dev/null)"
   if [[ -z "$CREW_LOCAL_REPO_ROOT" ]]; then
-    local CREW_LOCAL_PACKAGES_PATH="${CREW_PACKAGES_PATH}"
+    local CREW_LOCAL_REPO_ROOT_PACKAGES_PATH="${CREW_PACKAGES_PATH}"
   else
-    local CREW_LOCAL_PACKAGES_PATH="${CREW_LOCAL_REPO_ROOT}/packages/"
+    local CREW_LOCAL_REPO_ROOT_PACKAGES_PATH="${CREW_LOCAL_REPO_ROOT}/packages/"
   fi
 
   # available options
@@ -28,7 +28,6 @@ function _crew () {
 
   # available commands
   local cmds=(
-    autoremove
     build
     const
     deps
@@ -38,12 +37,15 @@ function _crew () {
     install
     list
     postinstall
+    prop
     reinstall
     remove
     search
     sysinfo
+    test
     update
     upgrade
+    upload
     whatprovides
   )
 
@@ -59,11 +61,12 @@ function _crew () {
     COMPREPLY=( $(compgen -W "${cmds[*]}" -- "${current}") )
   else
     # match ${current} with available packages
-    local matched_pkgs=( ${CREW_PACKAGES_PATH}/${current}*.rb ${CREW_LOCAL_PACKAGES_PATH}/${current}*.rb )
+    local matched_pkgs=( ${CREW_PACKAGES_PATH}/${current}*.rb )
+    local local_repo_root_matched_pkgs=( ${CREW_LOCAL_REPO_ROOT_PACKAGES_PATH}/${current}*.rb )
 
-    if [[ ${#matched_pkgs[@]} > 1 ]]; then
+    if [[ ${#matched_pkgs[@]} > 1 || ${#local_repo_root_matched_pkgs[@]} > 1 ]]; then
       # use basename to remove extension and path
-      COMPREPLY=( $(basename -s .rb ${matched_pkgs[@]}) )
+      COMPREPLY=( $(echo "$(basename -s .rb ${matched_pkgs[@]}) $(basename -s .rb ${local_repo_root_matched_pkgs[@]})") )
     else
       return 1
     fi

--- a/src/bash.d/01-crew
+++ b/src/bash.d/01-crew
@@ -3,6 +3,12 @@
 
 function _crew () {
   local CREW_PACKAGES_PATH="${CREW_PREFIX}/lib/crew/packages/"
+  local CREW_LOCAL_REPO_ROOT="$(git rev-parse --show-toplevel 2> /dev/null)"
+  if [[ -z "$CREW_LOCAL_REPO_ROOT" ]]; then
+    local CREW_LOCAL_PACKAGES_PATH="${CREW_PACKAGES_PATH}"
+  else
+    local CREW_LOCAL_PACKAGES_PATH="${CREW_LOCAL_REPO_ROOT}/packages/"
+  fi
 
   # available options
   local avail_opts_short=(-b -t -c -d -k -L -s -S -v -V -h)
@@ -53,7 +59,7 @@ function _crew () {
     COMPREPLY=( $(compgen -W "${cmds[*]}" -- "${current}") )
   else
     # match ${current} with available packages
-    local matched_pkgs=( ${CREW_PACKAGES_PATH}/${current}*.rb )
+    local matched_pkgs=( ${CREW_PACKAGES_PATH}/${current}*.rb ${CREW_LOCAL_PACKAGES_PATH}/${current}*.rb )
 
     if [[ ${#matched_pkgs[@]} > 1 ]]; then
       # use basename to remove extension and path
@@ -66,3 +72,4 @@ function _crew () {
 
 # register this function as completion function for crew command
 complete -F _crew crew
+

--- a/src/bash.d/01-crew
+++ b/src/bash.d/01-crew
@@ -66,7 +66,7 @@ function _crew () {
 
     if [[ ${#matched_pkgs[@]} > 1 || ${#local_repo_root_matched_pkgs[@]} > 1 ]]; then
       # use basename to remove extension and path
-      COMPREPLY=( $(echo "$(basename -s .rb ${matched_pkgs[@]}) $(basename -s .rb ${local_repo_root_matched_pkgs[@]})") )
+      COMPREPLY=( $(basename -s .rb ${matched_pkgs[@]} ${local_repo_root_matched_pkgs[@]}) )
     else
       return 1
     fi

--- a/src/profile
+++ b/src/profile
@@ -4,21 +4,26 @@
 # Instead, add custom environment variables to env.d/99-custom and
 # custom scripting to profile.d/99-custom
 
-# Export variables set (set allexport)
-set -a
+function _set_crew_variables () {
+  # Export variables set (set allexport)
+  set -a
+  local ARCH="$(uname -m)"
+  LIB_SUFFIX=''
+  [ "${ARCH}" = "x86_64" ] && LIB_SUFFIX='64'
 
-ARCH="$(uname -m)"
-LIB_SUFFIX=''
-[ "${ARCH}" = "x86_64" ] && LIB_SUFFIX='64'
+  # Find chromebrew prefix
+  # same logic can be found in lib/const.rb, line 17-25
+  : "${CREW_PREFIX:=/usr/local}"
 
-# Find chromebrew prefix
-# same logic can be found in lib/const.rb, line 17-25
-: "${CREW_PREFIX:=/usr/local}"
+  : "${CREW_LIB_PREFIX:=$CREW_PREFIX/lib$LIB_SUFFIX}"
 
-: "${CREW_LIB_PREFIX:=$CREW_PREFIX/lib$LIB_SUFFIX}"
+  # Find system configuration directory
+  CREW_SYSCONFDIR="${CREW_PREFIX}/etc"
 
-# Stop exporting variables set (unset allexport)
-set +a
+  # Stop exporting variables set (unset allexport)
+  set +a
+}
+_set_crew_variables
 
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
@@ -37,12 +42,6 @@ fi
 
 # Export variables set (set allexport)
 set -a
-
-# For container usage, where we are emulating armv7l via linux32
-ARCH="${ARCH/armv8l/armv7l}"
-
-# Find system configuration directory
-CREW_SYSCONFDIR="${CREW_PREFIX}/etc"
 
 # Disable hashing
 set +h


### PR DESCRIPTION
- Also removes defunct crew commands from bash autocompletion detection.
- This does not do anything to make crew handle packages that are in CREW_LOCAL_REPO_ROOT.