### PR TITLE
Make bash and zsh history written immediately

### DIFF
--- a/src/bash.d/02-history
+++ b/src/bash.d/02-history
@@ -1,0 +1,2 @@
+# Immediately save each command executed to history, so that crew opening a new shell on exit is less disruptive.
+PROMPT_COMMAND="history -a;$PROMPT_COMMAND"

--- a/src/zsh.d/01-history
+++ b/src/zsh.d/01-history
@@ -1,0 +1,2 @@
+# Immediately save each command executed to history, so that crew opening a new shell on exit is less disruptive.
+setopt inc_append_history


### PR DESCRIPTION
Some stuff for chromebrew/chromebrew#9516, figured its better to send it in now and let it work its way through things so that its ready by the time that one is sorted out.

Essentially, this means that `bash` and `zsh` save their histories to file immediately rather than storing them in memory and only saving on an explicit exit, allowing history to be passed to child shells, among other things. `fish` already does this, and at any rate we don't have any plumbing for `fish` here.


Will create PR in chromebrew repo after this is merged and tagged (I have pushed my tag to this PR, hopefully it will work as advertised).

Tested and working on `bash`, would appreciate testing on `zsh`.