### PR TITLE
Add plumbing for automatically sourcing ~/.bashrc

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -50,7 +50,6 @@ fi
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
   trap "source ~/.bashrc" USR1
-  export CREW_SOURCE_BASHRC_ACTIVATED=1
 fi
 
 # Load the zsh directory

--- a/src/profile
+++ b/src/profile
@@ -49,6 +49,7 @@ fi
 # Load the bash directory
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
+  trap "source ~/.bashrc" USR1
 fi
 
 # Load the zsh directory

--- a/src/profile
+++ b/src/profile
@@ -50,7 +50,7 @@ fi
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
   trap "source ~/.bashrc" USR1
-  export CREW_SOURCE_BASHRC_ENABLED=1
+  export CREW_SOURCE_BASHRC_ACTIVATED=1
 fi
 
 # Load the zsh directory

--- a/src/profile
+++ b/src/profile
@@ -50,6 +50,7 @@ fi
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
   trap "source ~/.bashrc" USR1
+  export CREW_SOURCE_BASHRC_ACTIVATED=1
 fi
 
 # Load the zsh directory

--- a/src/profile
+++ b/src/profile
@@ -50,8 +50,8 @@ fi
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
   trap "source ~/.bashrc" USR1
-  # open /tmp/.crew-autosource as file descriptor 20
-  exec 20> /tmp/.crew-autosource
+  # Change bash process name to indicate trap has been set.
+  echo -n "bash [trap set]" > /proc/$$/comm
 fi
 
 # Load the zsh directory

--- a/src/profile
+++ b/src/profile
@@ -50,7 +50,8 @@ fi
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
   trap "source ~/.bashrc" USR1
-  export CREW_SOURCE_BASHRC_ACTIVATED=1
+  # open /tmp/.crew-autosource as file descriptor 20
+  exec 20> /tmp/.crew-autosource
 fi
 
 # Load the zsh directory

--- a/src/profile
+++ b/src/profile
@@ -50,6 +50,7 @@ fi
 if [ -n "${BASH}" ]; then
   for i in "${CREW_SYSCONFDIR}"/bash.d/*; do [ -f "$i" ] && . "${i}"; done
   trap "source ~/.bashrc" USR1
+  export CREW_SOURCE_BASHRC_ENABLED=1
 fi
 
 # Load the zsh directory


### PR DESCRIPTION
The functionality here is used by https://github.com/chromebrew/chromebrew/pull/9649

As suggested in https://github.com/chromebrew/chromebrew/pull/9516#issuecomment-2045854314