### PR TITLE
Add glibc check function and fix bash loading function, make more robust to glibc breakage.

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -25,7 +25,7 @@ function _glibc_check () {
   # by a ChromeOS upgrade.
   crew_installed_glibc_version=$(/usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' /usr/local/etc/crew/device.json)
   installed_glibc_version=$(/lib"$LIB_SUFFIX"/libc.so.6 | /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')
-  if [ "$crew_installed_glibc_version" != "$installed_glibc_version" ]; then
+  if [ "${crew_installed_glibc_version%-*}" != "$installed_glibc_version" ]; then
     unset LD_LIBRARY_PATH
     /bin/grep .so /usr/local/etc/crew/meta/glibc_lib"${crew_installed_glibc_version//.}".filelist | /bin/grep -v gconv | /usr/bin/xargs /bin/rm -rf
     export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX

--- a/src/profile
+++ b/src/profile
@@ -20,6 +20,20 @@ function _set_crew_variables () {
 }
 _set_crew_variables
 
+function _glibc_check () {
+  # Workaround for if the ChromeOS glibc has been updated from under us
+  # by a ChromeOS upgrade.
+  crew_installed_glibc_version=$(/usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' /usr/local/etc/crew/device.json)
+  installed_glibc_version=$(/lib"$LIB_SUFFIX"/libc.so.6 | /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')
+  if [ "$crew_installed_glibc_version" != "$installed_glibc_version" ]; then
+    unset LD_LIBRARY_PATH
+    /bin/grep .so /usr/local/etc/crew/meta/glibc_lib"${crew_installed_glibc_version//.}".filelist | /bin/grep -v gconv | /usr/bin/xargs /bin/rm -rf
+    export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX
+    crew update ; yes | crew upgrade
+  fi
+}
+_glibc_check
+
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
 if [ -x "$CREW_PREFIX/bin/bash" ]; then

--- a/src/profile
+++ b/src/profile
@@ -24,7 +24,7 @@ function _glibc_check () {
   # Workaround for if the ChromeOS glibc has been updated from under us
   # by a ChromeOS upgrade.
   # OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-  crew_installed_glibc_version=$(LD_LIBRARY_PATH= /usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' /usr/local/etc/crew/device.json)
+  crew_installed_glibc_version=$(LD_LIBRARY_PATH= /usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' $CREW_PREFIX/etc/crew/device.json)
   crew_installed_glibc_package_version="${crew_installed_glibc_version//.}"
   crew_installed_glibc_package_name="glibc_lib${crew_installed_glibc_package_version%-*}"
   installed_glibc_version=$(LD_LIBRARY_PATH= /lib"$LIB_SUFFIX"/libc.so.6 | LD_LIBRARY_PATH= /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')

--- a/src/profile
+++ b/src/profile
@@ -5,7 +5,7 @@
 # custom scripting to profile.d/99-custom
 
 function _set_crew_variables () {
-  local ARCH="$(uname -m)"
+  local ARCH="$(LD_LIBRARY_PATH= /bin/uname -m)"
   export LIB_SUFFIX=''
   [ "${ARCH}" = "x86_64" ] && export LIB_SUFFIX='64'
 
@@ -23,24 +23,27 @@ _set_crew_variables
 function _glibc_check () {
   # Workaround for if the ChromeOS glibc has been updated from under us
   # by a ChromeOS upgrade.
-  crew_installed_glibc_version=$(/usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' /usr/local/etc/crew/device.json)
-  installed_glibc_version=$(/lib"$LIB_SUFFIX"/libc.so.6 | /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')
+  # OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+  crew_installed_glibc_version=$(LD_LIBRARY_PATH= /usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' /usr/local/etc/crew/device.json)
+  crew_installed_glibc_package_version="${crew_installed_glibc_version//.}"
+  crew_installed_glibc_package_name="glibc_lib${crew_installed_glibc_package_version%-*}"
+  installed_glibc_version=$(LD_LIBRARY_PATH= /lib"$LIB_SUFFIX"/libc.so.6 | LD_LIBRARY_PATH= /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')
   if [ "${crew_installed_glibc_version%-*}" != "$installed_glibc_version" ]; then
-    unset LD_LIBRARY_PATH
-    /bin/grep .so /usr/local/etc/crew/meta/glibc_lib"${crew_installed_glibc_version//.}".filelist | /bin/grep -v gconv | /usr/bin/xargs /bin/rm -rf
+    LD_LIBRARY_PATH= /bin/grep .so /usr/local/etc/crew/meta/"${crew_installed_glibc_package_name}".filelist | LD_LIBRARY_PATH=  /bin/grep -v gconv | LD_LIBRARY_PATH= /usr/bin/xargs /bin/rm -rf
     export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX
     crew update ; yes | crew upgrade
   fi
+  # LD_LIBRARY_PATH=$OLD_LD_LIBRARY_PATH
 }
 _glibc_check
 
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
 if [ -x "$CREW_PREFIX/bin/bash" ]; then
-  export CREW_BASH_VERSION=$("$CREW_PREFIX"/bin/bash --norc -c "echo \"$BASH_VERSION\"")
+  CREW_BASH_VERSION=$(LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash --norc --version | LD_LIBRARY_PATH= /usr/bin/awk 'NR==1{print $4}')
   if [ -n "$CREW_BASH_VERSION" ] && [ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]; then
     echo "Starting Chromebrew bash."
-    exec "$CREW_PREFIX"/bin/bash
+    exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash
   # else
     # echo "Chromebrew bash is not installed."
   fi

--- a/src/profile
+++ b/src/profile
@@ -29,7 +29,7 @@ function _glibc_check () {
   crew_installed_glibc_package_name="glibc_lib${crew_installed_glibc_package_version%-*}"
   installed_glibc_version=$(LD_LIBRARY_PATH= /lib"$LIB_SUFFIX"/libc.so.6 | LD_LIBRARY_PATH= /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')
   if [ "${crew_installed_glibc_version%-*}" != "$installed_glibc_version" ]; then
-    LD_LIBRARY_PATH= /bin/grep .so /usr/local/etc/crew/meta/"${crew_installed_glibc_package_name}".filelist | LD_LIBRARY_PATH=  /bin/grep -v gconv | LD_LIBRARY_PATH= /usr/bin/xargs /bin/rm -rf
+    LD_LIBRARY_PATH= /bin/grep .so $CREW_PREFIX/etc/crew/meta/"${crew_installed_glibc_package_name}".filelist | LD_LIBRARY_PATH=  /bin/grep -v gconv | LD_LIBRARY_PATH= /usr/bin/xargs /bin/rm -rf
     export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX
     crew update ; yes | crew upgrade
   fi


### PR DESCRIPTION
- Add a function to try to rescue situations where the system glibc is different from the Chromebrew installed glibc.
- Fix the function opening the Chromebrew bash when it is newer than the system bash. (This also fixes the library error when opening the arm container.)