### PR TITLE
fix i686 glibc package name detection as fallback, don't use crew bash in the container automatically

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -46,7 +46,10 @@ function _glibc_check () {
 _glibc_check
 
 # Container debug enablement.
-[[ -f /.dockerenv ]] && set -x
+if [[ -f /.dockerenv ]]; then
+  echo "in container: enabling debugging"
+  set -x
+fi
 
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
@@ -66,7 +69,10 @@ if [ -x "$CREW_PREFIX/bin/bash" ]; then
 fi
 
 # container debug disablement
-[[ -f /.dockerenv ]] && set +x
+if [[ -f /.dockerenv ]]; then
+  echo "disabling container debugging"
+  set +x
+fi
 
 # Source the base /etc/profile file
 . /etc/profile

--- a/src/profile
+++ b/src/profile
@@ -70,10 +70,10 @@ if [ -x "$CREW_PREFIX/bin/bash" ]; then
 fi
 
 # container debug disablement
-if [[ -f /.dockerenv ]]; then
-  echo "disabling container debugging"
-  set +x
-fi
+#if [[ -f /.dockerenv ]]; then
+  #echo "disabling container debugging"
+  #set +x
+#fi
 
 # Source the base /etc/profile file
 . /etc/profile

--- a/src/profile
+++ b/src/profile
@@ -43,37 +43,24 @@ function _glibc_check () {
   fi
   # LD_LIBRARY_PATH=$OLD_LD_LIBRARY_PATH
 }
-# _glibc_check
+_glibc_check
 
-# Container debug enablement.
-if [[ -f /.dockerenv ]]; then
-  echo "in container: enabling debugging"
-  set -x
-fi
-
+_crew_bash () {
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
 if [ -x "$CREW_PREFIX/bin/bash" ]; then
   CREW_BASH_VERSION=$(LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash --norc --version | LD_LIBRARY_PATH= /usr/bin/awk 'NR==1{print $4}')
   if [ -n "$CREW_BASH_VERSION" ] && [ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]; then
     echo "Starting Chromebrew bash."
-    # enable debugging for now if in container to figure out the unit test issues.
-    if [[ -f /.dockerenv ]]; then
-      echo "Running container specific command..."
-      exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash -x
-    else
-      exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash
-    fi
+    exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash "$@"
+  fi
   # else
     # echo "Chromebrew bash is not installed."
-  fi
+  # fi
 fi
-
-# container debug disablement
-#if [[ -f /.dockerenv ]]; then
-  #echo "disabling container debugging"
-  #set +x
-#fi
+}
+# This breaks passing a bash command line to docker containers.
+[[ -f /.dockerenv ]] || _crew_bash
 
 # Source the base /etc/profile file
 . /etc/profile

--- a/src/profile
+++ b/src/profile
@@ -59,6 +59,7 @@ if [ -x "$CREW_PREFIX/bin/bash" ]; then
     echo "Starting Chromebrew bash."
     # enable debugging for now if in container to figure out the unit test issues.
     if [[ -f /.dockerenv ]]; then
+      echo "Running container specific command..."
       exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash -x
     else
       exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash

--- a/src/profile
+++ b/src/profile
@@ -43,7 +43,7 @@ function _glibc_check () {
   fi
   # LD_LIBRARY_PATH=$OLD_LD_LIBRARY_PATH
 }
-_glibc_check
+# _glibc_check
 
 # Container debug enablement.
 if [[ -f /.dockerenv ]]; then

--- a/src/profile
+++ b/src/profile
@@ -23,7 +23,6 @@ _set_crew_variables
 function _glibc_check () {
   # Workaround for if the ChromeOS glibc has been updated from under us
   # by a ChromeOS upgrade.
-  # OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
   crew_installed_glibc_version=$(LD_LIBRARY_PATH= /usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' "$CREW_PREFIX"/etc/crew/device.json)
   crew_installed_glibc_package_version="${crew_installed_glibc_version//.}"
   crew_installed_glibc_package_name_a="glibc_lib${crew_installed_glibc_package_version%-*}"
@@ -42,7 +41,6 @@ function _glibc_check () {
     export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX
     crew update ; yes | crew upgrade
   fi
-  # LD_LIBRARY_PATH=$OLD_LD_LIBRARY_PATH
 }
 _glibc_check
 

--- a/src/profile
+++ b/src/profile
@@ -35,7 +35,8 @@ function _glibc_check () {
     elif [[ -f "$CREW_PREFIX"/etc/crew/meta/"${crew_installed_glibc_package_name_b}".filelist ]]; then
       crew_installed_glibc_package_filelist="$CREW_PREFIX"/etc/crew/meta/"${crew_installed_glibc_package_name_b}".filelist
     else
-      return 0 2>/dev/null || exit 0
+      # Return or exit depending upon whether script was sourced.
+      (return 0 2>/dev/null) && return 0 || exit 0
     fi
     LD_LIBRARY_PATH= /bin/grep .so "$crew_installed_glibc_package_filelist" | LD_LIBRARY_PATH=  /bin/grep -v gconv | LD_LIBRARY_PATH= /usr/bin/xargs /bin/rm -rf
     export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX

--- a/src/profile
+++ b/src/profile
@@ -24,12 +24,20 @@ function _glibc_check () {
   # Workaround for if the ChromeOS glibc has been updated from under us
   # by a ChromeOS upgrade.
   # OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-  crew_installed_glibc_version=$(LD_LIBRARY_PATH= /usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' $CREW_PREFIX/etc/crew/device.json)
+  crew_installed_glibc_version=$(LD_LIBRARY_PATH= /usr/bin/jq --arg key glibc -r '.installed_packages[] | select(.name == $key )| .version ' "$CREW_PREFIX"/etc/crew/device.json)
   crew_installed_glibc_package_version="${crew_installed_glibc_version//.}"
-  crew_installed_glibc_package_name="glibc_lib${crew_installed_glibc_package_version%-*}"
+  crew_installed_glibc_package_name_a="glibc_lib${crew_installed_glibc_package_version%-*}"
+  crew_installed_glibc_package_name_b="glibc_${crew_installed_glibc_package_version%-*}"
   installed_glibc_version=$(LD_LIBRARY_PATH= /lib"$LIB_SUFFIX"/libc.so.6 | LD_LIBRARY_PATH= /usr/bin/awk -F version 'NR==1{{gsub (" ", "", $0) ; print substr($2, 1, length($2)-1)}}')
   if [ "${crew_installed_glibc_version%-*}" != "$installed_glibc_version" ]; then
-    LD_LIBRARY_PATH= /bin/grep .so $CREW_PREFIX/etc/crew/meta/"${crew_installed_glibc_package_name}".filelist | LD_LIBRARY_PATH=  /bin/grep -v gconv | LD_LIBRARY_PATH= /usr/bin/xargs /bin/rm -rf
+    if [[ -f "$CREW_PREFIX"/etc/crew/meta/"${crew_installed_glibc_package_name_a}".filelist ]]; then
+      crew_installed_glibc_package_filelist="$CREW_PREFIX"/etc/crew/meta/"${crew_installed_glibc_package_name_a}".filelist
+    elif [[ -f "$CREW_PREFIX"/etc/crew/meta/"${crew_installed_glibc_package_name_b}".filelist ]]; then
+      crew_installed_glibc_package_filelist="$CREW_PREFIX"/etc/crew/meta/"${crew_installed_glibc_package_name_b}".filelist
+    else
+      return 0 2>/dev/null || exit 0
+    fi
+    LD_LIBRARY_PATH= /bin/grep .so "$crew_installed_glibc_package_filelist" | LD_LIBRARY_PATH=  /bin/grep -v gconv | LD_LIBRARY_PATH= /usr/bin/xargs /bin/rm -rf
     export LD_LIBRARY_PATH=$CREW_LIB_PREFIX:/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX
     crew update ; yes | crew upgrade
   fi
@@ -37,17 +45,28 @@ function _glibc_check () {
 }
 _glibc_check
 
+# Container debug enablement.
+[[ -f /.dockerenv ]] && set -x
+
 # Bash in path will be the Chromebrew bash if it is installed.
 # Switch to Chromebrew bash as early as possible if it is installed.
 if [ -x "$CREW_PREFIX/bin/bash" ]; then
   CREW_BASH_VERSION=$(LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash --norc --version | LD_LIBRARY_PATH= /usr/bin/awk 'NR==1{print $4}')
   if [ -n "$CREW_BASH_VERSION" ] && [ "${CREW_BASH_VERSION}" != "${BASH_VERSION}" ]; then
     echo "Starting Chromebrew bash."
-    exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash
+    # enable debugging for now if in container to figure out the unit test issues.
+    if [[ -f /.dockerenv ]]; then
+      exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash -x
+    else
+      exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash
+    fi
   # else
     # echo "Chromebrew bash is not installed."
   fi
 fi
+
+# container debug disablement
+[[ -f /.dockerenv ]] && set +x
 
 # Source the base /etc/profile file
 . /etc/profile

--- a/src/profile
+++ b/src/profile
@@ -54,9 +54,6 @@ if [ -x "$CREW_PREFIX/bin/bash" ]; then
     echo "Starting Chromebrew bash."
     exec env LD_LIBRARY_PATH="$CREW_LIB_PREFIX":/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX "$CREW_PREFIX"/bin/bash "$@"
   fi
-  # else
-    # echo "Chromebrew bash is not installed."
-  # fi
 fi
 }
 # This breaks passing a bash command line to docker containers.


### PR DESCRIPTION
- Isolated the crew bash code into a `_crew_bash` function, which does not run if in a container, as that code, and the bash reinvocation, appears to break bash -c invocation of the container. Not sure why.