### PR TITLE
Add 08-ca-certificates in env.d to fix ruby https requests

### DIFF
--- a/src/env.d/08-ca-certificates
+++ b/src/env.d/08-ca-certificates
@@ -1,0 +1,3 @@
+# Set the ssl certificates path for ruby.
+SSL_CERT_DIR="${CREW_PREFIX}/etc/ssl/certs"
+SSL_CERT_FILE="${CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
Making progress on fixing `net/http` making secure requests so that we can get rebuild support up and running again.

PLEASE test this on real hardware-- pulling down chromebrew/chromebrew#10152 is a good way to see if certificates are broken. containers clearly aren't able to catch this error, so I can't easily test.

also, if this works, we'll need to tag and push a new release so we can get this into chromebrew.