### PR TITLE
Make sure '-a' is set so env.d variables get exported

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -3,6 +3,7 @@
 # you have made.
 # Instead, add custom environment variables to env.d/99-custom and
 # custom scripting to profile.d/99-custom
+
 function _set_crew_variables () {
   local ARCH="$(LD_LIBRARY_PATH= /bin/uname -m)"
   export LIB_SUFFIX=''

--- a/src/profile
+++ b/src/profile
@@ -3,7 +3,6 @@
 # you have made.
 # Instead, add custom environment variables to env.d/99-custom and
 # custom scripting to profile.d/99-custom
-
 function _set_crew_variables () {
   local ARCH="$(LD_LIBRARY_PATH= /bin/uname -m)"
   export LIB_SUFFIX=''
@@ -69,7 +68,7 @@ _crew_bash () {
 set +h
 
 # Load the environment
-for i in "${CREW_SYSCONFDIR}"/env.d/*; do [ -f "$i" ] && . "${i}"; done
+for i in "${CREW_SYSCONFDIR}"/env.d/*; do set -a && [ -f "$i" ] && . "${i}" && set +a; done
 
 # Load the profile
 if [ -d "${CREW_SYSCONFDIR}"/profile.d ]; then


### PR DESCRIPTION
env.d variables should get automatically exported. Otherwise variables like `XML_CATALOG_FILES` are not getting set.