### PR TITLE
Add LIBC_VERSION & CHROMEOS_RELEASE_CHROME_MILESTONE env variables, so we can add them to the Chromebrew prompt

### DIFF
--- a/src/env.d/09-libc
+++ b/src/env.d/09-libc
@@ -1,0 +1,1 @@
+LIBC_VERSION=$(/lib"$LIB_SUFFIX"/libc.so.6 2>/dev/null | awk 'match($0, /Gentoo ([^-]+)/) {print substr($0, RSTART+7, RLENGTH-7)}')

--- a/src/env.d/10-milestone
+++ b/src/env.d/10-milestone
@@ -1,0 +1,1 @@
+CHROMEOS_RELEASE_CHROME_MILESTONE=$(grep CHROMEOS_RELEASE_CHROME_MILESTONE /etc/lsb-release | awk -F= '{print $2}')


### PR DESCRIPTION
This is connected to a forthcoming PR in chromebrew that will enable the git prompt to also list the glibc version a container is running on if the prompt is in a container.

(I find myself constantly running `crew const LIBC_VERSION` to figure out which container I am in.)