### PR TITLE
Allow force of ARCH with variable externally set.

### DIFF
--- a/src/profile
+++ b/src/profile
@@ -5,7 +5,9 @@
 # custom scripting to profile.d/99-custom
 
 function _set_crew_variables () {
-  local ARCH="$(LD_LIBRARY_PATH= /bin/uname -m)"
+  # Allow force set of ARCH externally.
+  local arch="$(LD_LIBRARY_PATH= /bin/uname -m)"
+  local ARCH="${ARCH:=${arch}}"
   export LIB_SUFFIX=''
   [ "${ARCH}" = "x86_64" ] && export LIB_SUFFIX='64'
 


### PR DESCRIPTION
i686 when loaded in a container in the install needs to have ARCH specified manually, since we are actually in a x86_64 container. (i686 container installs are currently failing.)

This leads to us doing this in the install.sh after we install `crew_profile_base`:
```bash
ARCH=$ARCH source ~/.bashrc
```