### PR TITLE
Unset default LD_LIBRARY_PATH and try not setting our own.

### DIFF
--- a/src/env.d/07-ld-library-path
+++ b/src/env.d/07-ld-library-path
@@ -5,4 +5,8 @@
 # Don't use `export LD_LIBRARY_PATH="${CREW_LIB_PREFIX}:${LD_LIBRARY_PATH}`, as it may
 # result in multiple copies of the same lines in $LD_LIBRARY_PATH.
 # Instead, only add ${CREW_LIB_PREFIX} to ${LD_LIBRARY_PATH} if it isn't there already.
-[[ "$LD_LIBRARY_PATH" == *"$CREW_LIB_PREFIX"* ]] || LD_LIBRARY_PATH="${CREW_LIB_PREFIX}:${LD_LIBRARY_PATH}"
+#
+# Disabled to see if we can get away without setting this, since we want our
+# LD_PRELOAD binary for a given binary's architecture to load depending upon
+# the architecture specific library path under our CREW_PREFIX.
+#[[ "$LD_LIBRARY_PATH" == *"$CREW_LIB_PREFIX"* ]] || LD_LIBRARY_PATH="${CREW_LIB_PREFIX}:${LD_LIBRARY_PATH}"

--- a/src/profile
+++ b/src/profile
@@ -6,6 +6,9 @@
 
 # Source the base /etc/profile file.
 . /etc/profile
+# We don't want /usr/local/lib64 automatically added to the path for
+# the newer aarch64/armv7l multiarch Milestone releases.
+unset LD_LIBRARY_PATH
 
 # Set allexport.
 set -a
@@ -33,7 +36,9 @@ _crew_restart_shell() {
   declare -i argc=0
 
   # Set LD_PRELOAD to crew-preload.so if it exists.
-  [ -x "${CREW_LIB_PREFIX}/crew-preload.so" ] && : "${LD_PRELOAD:=${CREW_LIB_PREFIX}/crew-preload.so}"
+  # The path to LD_PRELOAD should depend upon the default library search
+  # path, which is architecture dependent.
+  [ -x "${CREW_LIB_PREFIX}/crew-preload.so" ] && : "${LD_PRELOAD:=crew-preload.so}"
 
   # Extract parameters used to invoke the current shell from /proc/self/cmdline.
   { read -rd $'\0'; while read -rd $'\0' arg; do cmdline[$(( i++ ))]="${arg}"; done } < /proc/self/cmdline


### PR DESCRIPTION
- This is in the service of trying to use Architecture specific automatic LD_LIBRARY_PATH for multiarch arm systems.